### PR TITLE
code: add indentation at line breaks to fix broken markdown layout

### DIFF
--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -113,12 +113,15 @@ class Parser:
         if not output_lines:
             output_lines = []
 
+        indentation = " " * self.tab_size * indent_level
+        indentation_items = " " * self.tab_size * (indent_level + 1)
+
         # Construct full description line
-        description_line = self._construct_description_line(obj)
+        description_line_base = self._construct_description_line(obj)
+        description_line = list(map(lambda line: line.replace("\n\n", "<br>" + indentation_items), description_line_base))
 
         # Add full line to output
         description_line = " ".join(description_line)
-        indentation = " " * self.tab_size * indent_level
         obj_type = f" *({obj['type']})*" if "type" in obj else ""
         name_formatted = f"**`{name}`**" if name_monospace else f"**{name}**"
         output_lines.append(


### PR DESCRIPTION
It was like this:<img width="1028" alt="Screen Shot 2021-07-01 at 1 54 02 PM" src="https://user-images.githubusercontent.com/992894/124066561-dbe14580-da73-11eb-9758-47d706216f78.png">

And now it is like this:<img width="1025" alt="Screen Shot 2021-07-01 at 1 53 51 PM" src="https://user-images.githubusercontent.com/992894/124066579-e3085380-da73-11eb-89ec-8b0ea6efee08.png">