### PR TITLE
Fix #4 and add feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 04/09/2021
+- Fix Fenced code blocks should be surrounded by blank lines (Issue #4)
 
 ## [0.2.1] - 05/08/2021
 - Fix broken indentation for examples section (PR #3, thanks @KatekovAnton!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to
 
 ## [0.2.2] - 04/09/2021
 - Fix Fenced code blocks should be surrounded by blank lines (Issue #4)
+- Add `example_as_yaml` option
+- Add `show_example` option
 
 ## [0.2.1] - 05/08/2021
 - Fix broken indentation for examples section (PR #3, thanks @KatekovAnton!)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.2] - 04/09/2021
-- Fix Fenced code blocks should be surrounded by blank lines (Issue #4)
-- Add `example_as_yaml` option
-- Add `show_example` option
+## [0.3.0] - 16/12/2021
+
+### Bug fixes
+- Add `\n\n` at the end of example block (thanks @mysiki!)
+  - Fixes #4
+- Relax Click version requirement
+  - Fixes #7
+
+### New features
+- Option `examples-as-yaml` to show examples in YAML-format instead of JSON
+- Option `show-example` to select which examples need to be parsed: `all`, `object`, or `properties`
 
 ## [0.2.1] - 05/08/2021
 - Fix broken indentation for examples section (PR #3, thanks @KatekovAnton!)

--- a/README.md
+++ b/README.md
@@ -71,7 +71,26 @@ import jsonschema2md
 parser = jsonschema2md.Parser()
 md_lines = parser.parse_schema(json.load(input_json))
 ```
+### Options
 
+- Show example as Yaml format instead of JSON using `example_as_yaml` boolean (default `false`):
+
+  ```python
+  md_lines = parser.parse_schema(json.load(input_json), true)
+  ```
+
+- Selecte if you want to show all example or juste for Object or Propertie section (default `all`)
+
+  ```python
+  ## Show all examples
+  md_lines = parser.parse_schema(json.load(input_json), show_example='all')
+
+  ## Show only object section examples
+  md_lines = parser.parse_schema(json.load(input_json), show_example='object')
+
+  ## Show only properties section examples
+  md_lines = parser.parse_schema(json.load(input_json), show_example='propertie')
+  ```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ print(''.join(md_lines))
   ## Show only properties section examples
   md_lines = parser.parse_schema(input_json, show_example='propertie')
   print(''.join(md_lines))
+
+  ## Don't Show examples
+  md_lines = parser.parse_schema(input_json, show_example='any')
+  print(''.join(md_lines))
   ```
 
   ```sh

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ print(''.join(md_lines))
   ```
 
   ```sh
-  jsonschema2md --show-example=object True <input.json> <output.md>
+  jsonschema2md --show-example object <input.json> <output.md>
   ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -55,63 +55,39 @@ Install with pip
 pip install jsonschema2md
 ```
 
+
 ## Usage
 
 ### From the CLI
 
 ```sh
-jsonschema2md <input.json> <output.md>
+jsonschema2md [OPTIONS] <input.json> <output.md>
 ```
+
 
 ### From Python
 
 ```python
-import jsonschema2md
 import json
+import jsonschema2md
 
-with open("./examples/food.json","r") as json_file: input_json = json.load(json_file);
-
-parser = jsonschema2md.Parser()
-md_lines = parser.parse_schema(input_json)
+parser = jsonschema2md.Parser(
+    examples_as_yaml=False,
+    show_examples="all",
+)
+with open("./examples/food.json", "r") as json_file:
+    md_lines = parser.parse_schema(json.load(json_file))
 print(''.join(md_lines))
 ```
 
+
 ### Options
 
-- Show example as Yaml format instead of JSON using `example_as_yaml` boolean (default `false`):
+- `examples_as_yaml`: Parse examples in YAML-format instead of JSON. (`bool`, default:
+  `False`)
+- `show_examples`: Parse examples for only the main object, only properties, or all.
+(`str`, default `all`, options: `object`, `properties`, `all`)
 
-  ```python
-  md_lines = parser.parse_schema(input_json, example_as_yaml=True)
-  print(''.join(md_lines))
-  ```
-
-  ```sh
-  jsonschema2md --example-as-yaml True <input.json> <output.md>
-  ```
-
-- Selecte if you want to show all example or juste for Object or Propertie section (default `all`)
-
-  ```python
-  ## Show all examples
-  md_lines = parser.parse_schema(input_json, show_example='all')
-  print(''.join(md_lines))
-
-  ## Show only object section examples
-  md_lines = parser.parse_schema(input_json, show_example='object')
-  print(''.join(md_lines))
-
-  ## Show only properties section examples
-  md_lines = parser.parse_schema(input_json, show_example='propertie')
-  print(''.join(md_lines))
-
-  ## Don't Show examples
-  md_lines = parser.parse_schema(input_json, show_example='any')
-  print(''.join(md_lines))
-  ```
-
-  ```sh
-  jsonschema2md --show-example object <input.json> <output.md>
-  ```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -50,46 +50,63 @@ directory for more elaborate examples.
 ## Installation
 
 Install with pip
-```sh
-$ pip install jsonschema2md
-```
 
+```sh
+pip install jsonschema2md
+```
 
 ## Usage
 
 ### From the CLI
 
 ```sh
-$ jsonschema2md <input.json> <output.md>
+jsonschema2md <input.json> <output.md>
 ```
-
 
 ### From Python
 
 ```python
 import jsonschema2md
+import json
+
+with open("./examples/food.json","r") as json_file: input_json = json.load(json_file);
+
 parser = jsonschema2md.Parser()
-md_lines = parser.parse_schema(json.load(input_json))
+md_lines = parser.parse_schema(input_json)
+print(''.join(md_lines))
 ```
+
 ### Options
 
 - Show example as Yaml format instead of JSON using `example_as_yaml` boolean (default `false`):
 
   ```python
-  md_lines = parser.parse_schema(json.load(input_json), true)
+  md_lines = parser.parse_schema(input_json, example_as_yaml=True)
+  print(''.join(md_lines))
+  ```
+
+  ```sh
+  jsonschema2md --example-as-yaml True <input.json> <output.md>
   ```
 
 - Selecte if you want to show all example or juste for Object or Propertie section (default `all`)
 
   ```python
   ## Show all examples
-  md_lines = parser.parse_schema(json.load(input_json), show_example='all')
+  md_lines = parser.parse_schema(input_json, show_example='all')
+  print(''.join(md_lines))
 
   ## Show only object section examples
-  md_lines = parser.parse_schema(json.load(input_json), show_example='object')
+  md_lines = parser.parse_schema(input_json, show_example='object')
+  print(''.join(md_lines))
 
   ## Show only properties section examples
-  md_lines = parser.parse_schema(json.load(input_json), show_example='propertie')
+  md_lines = parser.parse_schema(input_json, show_example='propertie')
+  print(''.join(md_lines))
+  ```
+
+  ```sh
+  jsonschema2md --show-example=object True <input.json> <output.md>
   ```
 
 ## Contributing

--- a/examples/vegetables.json
+++ b/examples/vegetables.json
@@ -1,0 +1,32 @@
+{
+    "$id": "https://example.com/arrays.schema.json",
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "Vegetable preferences",
+    "type": "object",
+    "properties": {
+        "fruits": {"type": "array", "items": {"type": "string"}},
+        "vegetables": {"type": "array", "items": {"$ref": "#/definitions/veggie"}}
+    },
+    "definitions": {
+        "veggie": {
+            "type": "object",
+            "required": ["veggieName", "veggieLike"],
+            "properties": {
+                "veggieName": {
+                    "type": "string",
+                    "description": "The name of the vegetable."
+                },
+                "veggieLike": {
+                    "type": "boolean",
+                    "description": "Do I like this vegetable?"
+                }
+            }
+        }
+    },
+    "examples": [
+        {
+            "fruits": ["apple", "orange"],
+            "vegetables": [{"veggieName": "cabbage", "veggieLike": true}]
+        }
+    ]
+}

--- a/examples/vegetables.md
+++ b/examples/vegetables.md
@@ -1,0 +1,32 @@
+# JSON Schema
+
+*Vegetable preferences*
+
+## Properties
+
+- **`fruits`** *(array)*
+  - **Items** *(string)*
+- **`vegetables`** *(array)*
+  - **Items**: Refer to *#/definitions/veggie*.
+## Definitions
+
+- **`veggie`** *(object)*
+  - **`veggieName`** *(string)*: The name of the vegetable.
+  - **`veggieLike`** *(boolean)*: Do I like this vegetable?
+## Examples
+
+  ```json
+  {
+      "fruits": [
+          "apple",
+          "orange"
+      ],
+      "vegetables": [
+          {
+              "veggieName": "cabbage",
+              "veggieLike": true
+          }
+      ]
+  }
+  ```
+

--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -10,13 +10,14 @@ try:
     from importlib.metadata import version
 except ImportError:
     from importlib_metadata import version
+
+import io
 import json
-import yaml
 import re
 from typing import Dict, Optional, Sequence
-import io
 
 import click
+import yaml
 
 __version__ = version('jsonschema2md')
 
@@ -30,14 +31,38 @@ class Parser:
     >>> import jsonschema2md
     >>> parser = jsonschema2md.Parser()
     >>> md_lines = parser.parse_schema(json.load(input_json))
-
-    Options
-    --------
-    example_as_yaml: bool #Show example as yaml format (default Json)
-    show_example: str (all / object / propertie /any) #Show all example or selected. Only Objects example or properties example (default all)
     """
 
     tab_size = 2
+
+    def __init__(
+        self,
+        examples_as_yaml: bool = False,
+        show_examples: str = "all"
+    ):
+        """
+        Setup JSON Schema to Markdown parser.
+
+        Parameters
+        ----------
+        examples_as_yaml : bool, default False
+            Parse examples in YAML-format instead of JSON.
+        show_examples: str, default 'all'
+            Parse examples for only objects, only properties or all. Valid options are
+            `{"all", "object", "properties"}`.
+
+        """
+        self.examples_as_yaml = examples_as_yaml
+
+        valid_show_examples_options = ["all", "object", "properties"]
+        show_examples = show_examples.lower()
+        if show_examples in valid_show_examples_options:
+            self.show_examples = show_examples
+        else:
+            raise ValueError(
+                f"`show_examples` option should be one of "
+                f"`{valid_show_examples_options}`; `{show_examples}` was passed."
+            )
 
     def _construct_description_line(
         self,
@@ -79,8 +104,7 @@ class Parser:
         self,
         obj: Dict,
         indent_level: int = 0,
-        add_header: bool = True,
-        example_as_yaml: bool = False,
+        add_header: bool = True
     ) -> Sequence[str]:
         def dump_json_with_line_head(obj, line_head, **kwargs):
             f = io.StringIO(json.dumps(obj, **kwargs))
@@ -90,7 +114,7 @@ class Parser:
         def dump_yaml_with_line_head(obj, line_head, **kwargs):
             f = io.StringIO(yaml.dump(obj, **kwargs))
             result = [line_head + line for line in f.readlines()]
-            return ''.join(result)
+            return ''.join(result).rstrip()
 
         example_lines = []
         if "examples" in obj:
@@ -98,25 +122,22 @@ class Parser:
             if add_header:
                 example_lines.append(f'\n{example_indentation}Examples:\n')
             for example in obj["examples"]:
-                if example_as_yaml:
-                    example_str = dump_yaml_with_line_head(
-                        example,
-                        line_head=example_indentation,
-                        indent=4
-                    )
-                    example_lines.append(
-                        f"{example_indentation}```yaml\n{example_str}\n{example_indentation}```\n\n"
-                    )
+                if self.examples_as_yaml:
+                    lang = "yaml"
+                    dump_fn = dump_yaml_with_line_head
                 else:
-                    example_str = dump_json_with_line_head(
-                        example,
-                        line_head=example_indentation,
-                        indent=4
-                    )
-                    example_lines.append(
-                        f"{example_indentation}```json\n{example_str}\n{example_indentation}```\n\n"
-                    )
-
+                    lang = "json"
+                    dump_fn = dump_json_with_line_head
+                example_str = dump_fn(
+                    example,
+                    line_head=example_indentation,
+                    indent=4
+                )
+                example_lines.append(
+                    f"{example_indentation}```{lang}\n"
+                    f"{example_str}\n"
+                    f"{example_indentation}```\n\n"
+                )
         return example_lines
 
     def _parse_object(
@@ -126,8 +147,6 @@ class Parser:
         name_monospace: bool = True,
         output_lines: Optional[str] = None,
         indent_level: int = 0,
-        example_as_yaml: bool = False,
-        show_example: str = 'all'
     ) -> Sequence[str]:
         """Parse JSON object and its items, definitions, and properties recursively."""
         if not isinstance(obj, dict):
@@ -161,9 +180,7 @@ class Parser:
                     name,
                     name_monospace=False,
                     output_lines=output_lines,
-                    indent_level=indent_level + 1,
-                    example_as_yaml=example_as_yaml,
-                    show_example=show_example
+                    indent_level=indent_level + 1
                 )
 
         # Recursively add child properties
@@ -174,21 +191,20 @@ class Parser:
                     property_name,
                     output_lines=output_lines,
                     indent_level=indent_level + 1,
-                    example_as_yaml=example_as_yaml,
-                    show_example=show_example
                 )
 
         # Add examples
-        if (show_example == 'all' or show_example == 'propertie'):
+        if self.show_examples in ["all", "properties"]:
             output_lines.extend(
-                self._construct_examples(obj, indent_level=indent_level, example_as_yaml=example_as_yaml)
+                self._construct_examples(obj, indent_level=indent_level)
             )
 
         return output_lines
 
-    def parse_schema(self, schema_object: Dict, show_example: str = 'all', example_as_yaml: bool = False) -> Sequence[str]:
+    def parse_schema(self, schema_object: Dict) -> Sequence[str]:
         """Parse JSON Schema object to markdown text."""
         output_lines = []
+
         # Add title and description
         if "title" in schema_object:
             output_lines.append(f"# {schema_object['title']}\n\n")
@@ -202,13 +218,13 @@ class Parser:
             if name.lower() in schema_object:
                 output_lines.append(f"## {name}\n\n")
                 for obj_name, obj in schema_object[name.lower()].items():
-                    output_lines.extend(self._parse_object(obj, obj_name, example_as_yaml=example_as_yaml, show_example=show_example))
+                    output_lines.extend(self._parse_object(obj, obj_name))
 
         # Add examples
-        if "examples" in schema_object and (show_example == 'all' or show_example == 'object'):
+        if "examples" in schema_object and self.show_examples in ["all", "object"]:
             output_lines.append("## Examples\n\n")
             output_lines.extend(self._construct_examples(
-                schema_object, indent_level=0, add_header=False, example_as_yaml=example_as_yaml
+                schema_object, indent_level=0, add_header=False
             ))
 
         return output_lines
@@ -218,12 +234,25 @@ class Parser:
 @click.version_option(version=__version__)
 @click.argument("input-json", type=click.File("rt"), metavar="<input.json>")
 @click.argument("output-markdown", type=click.File("wt"), metavar="<output.md>")
-@click.option("--example-as-yaml", type=bool, default=False, help="Show example as yaml format (default json)")
-@click.option("--show-example", type=click.Choice(['all', 'propertie', 'object', 'any'], case_sensitive=False), default='all', help="Selected type example to show")
-def main(input_json, output_markdown, example_as_yaml, show_example):
+@click.option(
+    "--examples-as-yaml",
+    type=bool,
+    default=False,
+    help="Parse examples in YAML-format instead of JSON."
+)
+@click.option(
+    "--show-examples",
+    type=click.Choice(['all', 'properties', 'object'], case_sensitive=False),
+    default='all',
+    help="Parse examples for only the main object, only properties, or all."
+)
+def main(input_json, output_markdown, examples_as_yaml, show_examples):
     """Convert JSON Schema to Markdown documentation."""
-    parser = Parser()
-    output_md = parser.parse_schema(json.load(input_json), example_as_yaml=example_as_yaml, show_example=show_example )
+    parser = Parser(
+        examples_as_yaml=examples_as_yaml,
+        show_examples=show_examples
+    )
+    output_md = parser.parse_schema(json.load(input_json))
     output_markdown.writelines(output_md)
     click.secho("✔ Successfully parsed schema!", bold=True, fg="green")
 

--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -218,10 +218,12 @@ class Parser:
 @click.version_option(version=__version__)
 @click.argument("input-json", type=click.File("rt"), metavar="<input.json>")
 @click.argument("output-markdown", type=click.File("wt"), metavar="<output.md>")
-def main(input_json, output_markdown):
+@click.option("--example-as-yaml", type=bool, default=False, help="Show example as yaml format (default json)")
+@click.option("--show-example", type=click.Choice(['all', 'propertie', 'object'], case_sensitive=False), default='all', help="Selected type example to show")
+def main(input_json, output_markdown, example_as_yaml, show_example):
     """Convert JSON Schema to Markdown documentation."""
     parser = Parser()
-    output_md = parser.parse_schema(json.load(input_json))
+    output_md = parser.parse_schema(json.load(input_json), example_as_yaml=example_as_yaml, show_example=show_example )
     output_markdown.writelines(output_md)
     click.secho("✔ Successfully parsed schema!", bold=True, fg="green")
 

--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -84,7 +84,7 @@ class Parser:
         if "examples" in obj:
             example_indentation = " " * self.tab_size * (indent_level + 1)
             if add_header:
-                example_lines.append(f'\n{example_indentation}Examples:\n')
+                example_lines.append(f'\n{example_indentation}Examples:\n\n')
             for example in obj["examples"]:
                 example_str = dump_json_with_line_head(
                     example,
@@ -92,7 +92,7 @@ class Parser:
                     indent=4
                 )
                 example_lines.append(
-                    f"{example_indentation}```json\n{example_str}\n{example_indentation}```\n"
+                    f"{example_indentation}```json\n{example_str}\n{example_indentation}```\n\n"
                 )
         return example_lines
 

--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -34,7 +34,7 @@ class Parser:
     Options
     --------
     example_as_yaml: bool #Show example as yaml format (default Json)
-    show_example: str (all / object / propertie) #Show all example or selected. Only Objects example or properties example (default all)
+    show_example: str (all / object / propertie /any) #Show all example or selected. Only Objects example or properties example (default all)
     """
 
     tab_size = 2
@@ -219,7 +219,7 @@ class Parser:
 @click.argument("input-json", type=click.File("rt"), metavar="<input.json>")
 @click.argument("output-markdown", type=click.File("wt"), metavar="<output.md>")
 @click.option("--example-as-yaml", type=bool, default=False, help="Show example as yaml format (default json)")
-@click.option("--show-example", type=click.Choice(['all', 'propertie', 'object'], case_sensitive=False), default='all', help="Selected type example to show")
+@click.option("--show-example", type=click.Choice(['all', 'propertie', 'object', 'any'], case_sensitive=False), default='all', help="Selected type example to show")
 def main(input_json, output_markdown, example_as_yaml, show_example):
     """Convert JSON Schema to Markdown documentation."""
     parser = Parser()

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,78 +1,77 @@
 [[package]]
-category = "dev"
-description = "Atomic file writes."
-marker = "sys_platform == \"win32\""
 name = "atomicwrites"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 version = "1.4.0"
-
-[[package]]
+description = "Atomic file writes."
 category = "dev"
-description = "Classes Without Boilerplate"
-name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.1.0"
-
-[package.extras]
-dev = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["coverage (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 
 [[package]]
-category = "main"
-description = "Composable command line interface toolkit"
+name = "attrs"
+version = "21.2.0"
+description = "Classes Without Boilerplate"
+category = "dev"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit"]
+docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
+tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface"]
+tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins"]
+
+[[package]]
 name = "click"
+version = "8.0.3"
+description = "Composable command line interface toolkit"
+category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "7.1.2"
-
-[[package]]
-category = "dev"
-description = "Cross-platform colored terminal text."
-marker = "sys_platform == \"win32\""
-name = "colorama"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.4.3"
-
-[[package]]
-category = "dev"
-description = "Code coverage measurement for Python"
-name = "coverage"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
-version = "5.2.1"
-
-[package.extras]
-toml = ["toml"]
-
-[[package]]
-category = "dev"
-description = "the modular source code checker: pep8 pyflakes and co"
-name = "flake8"
-optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "3.8.3"
+python-versions = ">=3.6"
 
 [package.dependencies]
-mccabe = ">=0.6.0,<0.7.0"
-pycodestyle = ">=2.6.0a1,<2.7.0"
-pyflakes = ">=2.2.0,<2.3.0"
-
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = "*"
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
+name = "colorama"
+version = "0.4.4"
+description = "Cross-platform colored terminal text."
 category = "main"
-description = "Read metadata from Python packages"
-marker = "python_version < \"3.8\""
-name = "importlib-metadata"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "coverage"
+version = "6.2"
+description = "Code coverage measurement for Python"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.extras]
+toml = ["tomli"]
+
+[[package]]
+name = "flake8"
+version = "3.9.2"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[package.dependencies]
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
+mccabe = ">=0.6.0,<0.7.0"
+pycodestyle = ">=2.7.0,<2.8.0"
+pyflakes = ">=2.3.0,<2.4.0"
+
+[[package]]
+name = "importlib-metadata"
 version = "1.7.0"
+description = "Read metadata from Python packages"
+category = "main"
+optional = false
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 
 [package.dependencies]
 zipp = ">=0.5"
@@ -82,183 +81,171 @@ docs = ["sphinx", "rst.linker"]
 testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
 
 [[package]]
-category = "dev"
-description = "iniconfig: brain-dead simple config-ini parsing"
 name = "iniconfig"
+version = "1.1.1"
+description = "iniconfig: brain-dead simple config-ini parsing"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "1.0.1"
 
 [[package]]
-category = "dev"
-description = "McCabe checker, plugin for flake8"
 name = "mccabe"
+version = "0.6.1"
+description = "McCabe checker, plugin for flake8"
+category = "dev"
 optional = false
 python-versions = "*"
-version = "0.6.1"
 
 [[package]]
-category = "dev"
-description = "More routines for operating on iterables, beyond itertools"
-name = "more-itertools"
-optional = false
-python-versions = ">=3.5"
-version = "8.5.0"
-
-[[package]]
-category = "dev"
-description = "Core utilities for Python packages"
 name = "packaging"
+version = "21.3"
+description = "Core utilities for Python packages"
+category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.4"
+python-versions = ">=3.6"
 
 [package.dependencies]
-pyparsing = ">=2.0.2"
-six = "*"
+pyparsing = ">=2.0.2,<3.0.5 || >3.0.5"
 
 [[package]]
-category = "dev"
-description = "plugin and hook calling mechanisms for python"
 name = "pluggy"
+version = "1.0.0"
+description = "plugin and hook calling mechanisms for python"
+category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "0.13.1"
+python-versions = ">=3.6"
 
 [package.dependencies]
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
-category = "dev"
-description = "library with cross-python path, ini-parsing, io, code, log facilities"
 name = "py"
+version = "1.11.0"
+description = "library with cross-python path, ini-parsing, io, code, log facilities"
+category = "dev"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "1.9.0"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
-category = "dev"
-description = "Python style guide checker"
 name = "pycodestyle"
+version = "2.7.0"
+description = "Python style guide checker"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.6.0"
 
 [[package]]
-category = "dev"
-description = "Python docstring style checker"
 name = "pydocstyle"
+version = "5.1.1"
+description = "Python docstring style checker"
+category = "dev"
 optional = false
 python-versions = ">=3.5"
-version = "5.1.1"
 
 [package.dependencies]
 snowballstemmer = "*"
 
 [[package]]
-category = "dev"
-description = "passive checker of Python programs"
 name = "pyflakes"
+version = "2.3.1"
+description = "passive checker of Python programs"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "2.2.0"
 
 [[package]]
-category = "dev"
-description = "Python parsing module"
 name = "pyparsing"
+version = "3.0.6"
+description = "Python parsing module"
+category = "dev"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "2.4.7"
+python-versions = ">=3.6"
+
+[package.extras]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
-category = "dev"
-description = "pytest: simple powerful testing with Python"
 name = "pytest"
+version = "6.2.5"
+description = "pytest: simple powerful testing with Python"
+category = "dev"
 optional = false
-python-versions = ">=3.5"
-version = "6.0.1"
+python-versions = ">=3.6"
 
 [package.dependencies]
-atomicwrites = ">=1.0"
-attrs = ">=17.4.0"
-colorama = "*"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
+attrs = ">=19.2.0"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 iniconfig = "*"
-more-itertools = ">=4.0.0"
 packaging = "*"
-pluggy = ">=0.12,<1.0"
+pluggy = ">=0.12,<2.0"
 py = ">=1.8.2"
 toml = "*"
 
-[package.dependencies.importlib-metadata]
-python = "<3.8"
-version = ">=0.12"
-
 [package.extras]
-checkqa_mypy = ["mypy (0.780)"]
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
-category = "dev"
-description = "Pytest plugin for measuring coverage."
 name = "pytest-cov"
+version = "2.12.1"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "2.10.1"
 
 [package.dependencies]
-coverage = ">=4.4"
+coverage = ">=5.2.1"
 pytest = ">=4.6"
+toml = "*"
 
 [package.extras]
-testing = ["fields", "hunter", "process-tests (2.0.2)", "six", "pytest-xdist", "virtualenv"]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
 
 [[package]]
-category = "dev"
-description = "Python 2 and 3 compatibility utilities"
-name = "six"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.15.0"
-
-[[package]]
-category = "dev"
-description = "This package provides 26 stemmers for 25 languages generated from Snowball algorithms."
-name = "snowballstemmer"
-optional = false
-python-versions = "*"
-version = "2.0.0"
-
-[[package]]
-category = "dev"
-description = "Python Library for Tom's Obvious, Minimal Language"
-name = "toml"
-optional = false
-python-versions = "*"
-version = "0.10.1"
-
-[[package]]
+name = "pyyaml"
+version = "6.0"
+description = "YAML parser and emitter for Python"
 category = "main"
-description = "Backport of pathlib-compatible object wrapper for zip files"
-marker = "python_version < \"3.8\""
-name = "zipp"
 optional = false
 python-versions = ">=3.6"
-version = "3.1.0"
+
+[[package]]
+name = "snowballstemmer"
+version = "2.2.0"
+description = "This package provides 29 stemmers for 28 languages generated from Snowball algorithms."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "toml"
+version = "0.10.2"
+description = "Python Library for Tom's Obvious, Minimal Language"
+category = "dev"
+optional = false
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
+
+[[package]]
+name = "zipp"
+version = "3.6.0"
+description = "Backport of pathlib-compatible object wrapper for zip files"
+category = "main"
+optional = false
+python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["jaraco.itertools", "func-timeout"]
+docs = ["sphinx", "jaraco.packaging (>=8.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy"]
 
 [metadata]
-content-hash = "cc43fbad94a15184c186af68de2cd8b4bc80fe716aa4fe446c2638e84dbb653c"
-lock-version = "1.0"
+lock-version = "1.1"
 python-versions = "^3.6"
+content-hash = "56595d58c6011140a393ad339e99fb3cd45d5d0e09fdd2781813bdd174ebc39c"
 
 [metadata.files]
 atomicwrites = [
@@ -266,122 +253,162 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.1.0-py2.py3-none-any.whl", hash = "sha256:2867b7b9f8326499ab5b0e2d12801fa5c98842d2cbd22b35112ae04bf85b4dff"},
-    {file = "attrs-20.1.0.tar.gz", hash = "sha256:0ef97238856430dcf9228e07f316aefc17e8939fc8507e18c6501b761ef1a42a"},
+    {file = "attrs-21.2.0-py2.py3-none-any.whl", hash = "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1"},
+    {file = "attrs-21.2.0.tar.gz", hash = "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"},
 ]
 click = [
-    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
-    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+    {file = "click-8.0.3-py3-none-any.whl", hash = "sha256:353f466495adaeb40b6b5f592f9f91cb22372351c84caeb068132442a4518ef3"},
+    {file = "click-8.0.3.tar.gz", hash = "sha256:410e932b050f5eed773c4cda94de75971c89cdb3155a72a0831139a79e5ecb5b"},
 ]
 colorama = [
-    {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
-    {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
+    {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
+    {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
 ]
 coverage = [
-    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_13_intel.whl", hash = "sha256:40f70f81be4d34f8d491e55936904db5c527b0711b2a46513641a5729783c2e4"},
-    {file = "coverage-5.2.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:675192fca634f0df69af3493a48224f211f8db4e84452b08d5fcebb9167adb01"},
-    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2fcc8b58953d74d199a1a4d633df8146f0ac36c4e720b4a1997e9b6327af43a8"},
-    {file = "coverage-5.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:64c4f340338c68c463f1b56e3f2f0423f7b17ba6c3febae80b81f0e093077f59"},
-    {file = "coverage-5.2.1-cp27-cp27m-win32.whl", hash = "sha256:52f185ffd3291196dc1aae506b42e178a592b0b60a8610b108e6ad892cfc1bb3"},
-    {file = "coverage-5.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:30bc103587e0d3df9e52cd9da1dd915265a22fad0b72afe54daf840c984b564f"},
-    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:9ea749fd447ce7fb1ac71f7616371f04054d969d412d37611716721931e36efd"},
-    {file = "coverage-5.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:ce7866f29d3025b5b34c2e944e66ebef0d92e4a4f2463f7266daa03a1332a651"},
-    {file = "coverage-5.2.1-cp35-cp35m-macosx_10_13_x86_64.whl", hash = "sha256:4869ab1c1ed33953bb2433ce7b894a28d724b7aa76c19b11e2878034a4e4680b"},
-    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a3ee9c793ffefe2944d3a2bd928a0e436cd0ac2d9e3723152d6fd5398838ce7d"},
-    {file = "coverage-5.2.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:28f42dc5172ebdc32622a2c3f7ead1b836cdbf253569ae5673f499e35db0bac3"},
-    {file = "coverage-5.2.1-cp35-cp35m-win32.whl", hash = "sha256:e26c993bd4b220429d4ec8c1468eca445a4064a61c74ca08da7429af9bc53bb0"},
-    {file = "coverage-5.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:4186fc95c9febeab5681bc3248553d5ec8c2999b8424d4fc3a39c9cba5796962"},
-    {file = "coverage-5.2.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:b360d8fd88d2bad01cb953d81fd2edd4be539df7bfec41e8753fe9f4456a5082"},
-    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:1adb6be0dcef0cf9434619d3b892772fdb48e793300f9d762e480e043bd8e716"},
-    {file = "coverage-5.2.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:098a703d913be6fbd146a8c50cc76513d726b022d170e5e98dc56d958fd592fb"},
-    {file = "coverage-5.2.1-cp36-cp36m-win32.whl", hash = "sha256:962c44070c281d86398aeb8f64e1bf37816a4dfc6f4c0f114756b14fc575621d"},
-    {file = "coverage-5.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b1ed2bdb27b4c9fc87058a1cb751c4df8752002143ed393899edb82b131e0546"},
-    {file = "coverage-5.2.1-cp37-cp37m-macosx_10_13_x86_64.whl", hash = "sha256:c890728a93fffd0407d7d37c1e6083ff3f9f211c83b4316fae3778417eab9811"},
-    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:538f2fd5eb64366f37c97fdb3077d665fa946d2b6d95447622292f38407f9258"},
-    {file = "coverage-5.2.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:27ca5a2bc04d68f0776f2cdcb8bbd508bbe430a7bf9c02315cd05fb1d86d0034"},
-    {file = "coverage-5.2.1-cp37-cp37m-win32.whl", hash = "sha256:aab75d99f3f2874733946a7648ce87a50019eb90baef931698f96b76b6769a46"},
-    {file = "coverage-5.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:c2ff24df02a125b7b346c4c9078c8936da06964cc2d276292c357d64378158f8"},
-    {file = "coverage-5.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:304fbe451698373dc6653772c72c5d5e883a4aadaf20343592a7abb2e643dae0"},
-    {file = "coverage-5.2.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c96472b8ca5dc135fb0aa62f79b033f02aa434fb03a8b190600a5ae4102df1fd"},
-    {file = "coverage-5.2.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8505e614c983834239f865da2dd336dcf9d72776b951d5dfa5ac36b987726e1b"},
-    {file = "coverage-5.2.1-cp38-cp38-win32.whl", hash = "sha256:700997b77cfab016533b3e7dbc03b71d33ee4df1d79f2463a318ca0263fc29dd"},
-    {file = "coverage-5.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:46794c815e56f1431c66d81943fa90721bb858375fb36e5903697d5eef88627d"},
-    {file = "coverage-5.2.1-cp39-cp39-macosx_10_13_x86_64.whl", hash = "sha256:16042dc7f8e632e0dcd5206a5095ebd18cb1d005f4c89694f7f8aafd96dd43a3"},
-    {file = "coverage-5.2.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c1bbb628ed5192124889b51204de27c575b3ffc05a5a91307e7640eff1d48da4"},
-    {file = "coverage-5.2.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:4f6428b55d2916a69f8d6453e48a505c07b2245653b0aa9f0dee38785939f5e4"},
-    {file = "coverage-5.2.1-cp39-cp39-win32.whl", hash = "sha256:9e536783a5acee79a9b308be97d3952b662748c4037b6a24cbb339dc7ed8eb89"},
-    {file = "coverage-5.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8f58c7db64d8f27078cbf2a4391af6aa4e4767cc08b37555c4ae064b8558d9b"},
-    {file = "coverage-5.2.1.tar.gz", hash = "sha256:a34cb28e0747ea15e82d13e14de606747e9e484fb28d63c999483f5d5188e89b"},
+    {file = "coverage-6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6dbc1536e105adda7a6312c778f15aaabe583b0e9a0b0a324990334fd458c94b"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:174cf9b4bef0db2e8244f82059a5a72bd47e1d40e71c68ab055425172b16b7d0"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:92b8c845527eae547a2a6617d336adc56394050c3ed8a6918683646328fbb6da"},
+    {file = "coverage-6.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c7912d1526299cb04c88288e148c6c87c0df600eca76efd99d84396cfe00ef1d"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:d5d2033d5db1d58ae2d62f095e1aefb6988af65b4b12cb8987af409587cc0739"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:3feac4084291642165c3a0d9eaebedf19ffa505016c4d3db15bfe235718d4971"},
+    {file = "coverage-6.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:276651978c94a8c5672ea60a2656e95a3cce2a3f31e9fb2d5ebd4c215d095840"},
+    {file = "coverage-6.2-cp310-cp310-win32.whl", hash = "sha256:f506af4f27def639ba45789fa6fde45f9a217da0be05f8910458e4557eed020c"},
+    {file = "coverage-6.2-cp310-cp310-win_amd64.whl", hash = "sha256:3f7c17209eef285c86f819ff04a6d4cbee9b33ef05cbcaae4c0b4e8e06b3ec8f"},
+    {file = "coverage-6.2-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:13362889b2d46e8d9f97c421539c97c963e34031ab0cb89e8ca83a10cc71ac76"},
+    {file = "coverage-6.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:22e60a3ca5acba37d1d4a2ee66e051f5b0e1b9ac950b5b0cf4aa5366eda41d47"},
+    {file = "coverage-6.2-cp311-cp311-win_amd64.whl", hash = "sha256:b637c57fdb8be84e91fac60d9325a66a5981f8086c954ea2772efe28425eaf64"},
+    {file = "coverage-6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f467bbb837691ab5a8ca359199d3429a11a01e6dfb3d9dcc676dc035ca93c0a9"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2641f803ee9f95b1f387f3e8f3bf28d83d9b69a39e9911e5bfee832bea75240d"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:1219d760ccfafc03c0822ae2e06e3b1248a8e6d1a70928966bafc6838d3c9e48"},
+    {file = "coverage-6.2-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:9a2b5b52be0a8626fcbffd7e689781bf8c2ac01613e77feda93d96184949a98e"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:8e2c35a4c1f269704e90888e56f794e2d9c0262fb0c1b1c8c4ee44d9b9e77b5d"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:5d6b09c972ce9200264c35a1d53d43ca55ef61836d9ec60f0d44273a31aa9f17"},
+    {file = "coverage-6.2-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:e3db840a4dee542e37e09f30859f1612da90e1c5239a6a2498c473183a50e781"},
+    {file = "coverage-6.2-cp36-cp36m-win32.whl", hash = "sha256:4e547122ca2d244f7c090fe3f4b5a5861255ff66b7ab6d98f44a0222aaf8671a"},
+    {file = "coverage-6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:01774a2c2c729619760320270e42cd9e797427ecfddd32c2a7b639cdc481f3c0"},
+    {file = "coverage-6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:fb8b8ee99b3fffe4fd86f4c81b35a6bf7e4462cba019997af2fe679365db0c49"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:619346d57c7126ae49ac95b11b0dc8e36c1dd49d148477461bb66c8cf13bb521"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:0a7726f74ff63f41e95ed3a89fef002916c828bb5fcae83b505b49d81a066884"},
+    {file = "coverage-6.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:cfd9386c1d6f13b37e05a91a8583e802f8059bebfccde61a418c5808dea6bbfa"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:17e6c11038d4ed6e8af1407d9e89a2904d573be29d51515f14262d7f10ef0a64"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:c254b03032d5a06de049ce8bca8338a5185f07fb76600afff3c161e053d88617"},
+    {file = "coverage-6.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:dca38a21e4423f3edb821292e97cec7ad38086f84313462098568baedf4331f8"},
+    {file = "coverage-6.2-cp37-cp37m-win32.whl", hash = "sha256:600617008aa82032ddeace2535626d1bc212dfff32b43989539deda63b3f36e4"},
+    {file = "coverage-6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bf154ba7ee2fd613eb541c2bc03d3d9ac667080a737449d1a3fb342740eb1a74"},
+    {file = "coverage-6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9afb5b746781fc2abce26193d1c817b7eb0e11459510fba65d2bd77fe161d9e"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:edcada2e24ed68f019175c2b2af2a8b481d3d084798b8c20d15d34f5c733fa58"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a9c8c4283e17690ff1a7427123ffb428ad6a52ed720d550e299e8291e33184dc"},
+    {file = "coverage-6.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f614fc9956d76d8a88a88bb41ddc12709caa755666f580af3a688899721efecd"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:9365ed5cce5d0cf2c10afc6add145c5037d3148585b8ae0e77cc1efdd6aa2953"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:8bdfe9ff3a4ea37d17f172ac0dff1e1c383aec17a636b9b35906babc9f0f5475"},
+    {file = "coverage-6.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:63c424e6f5b4ab1cf1e23a43b12f542b0ec2e54f99ec9f11b75382152981df57"},
+    {file = "coverage-6.2-cp38-cp38-win32.whl", hash = "sha256:49dbff64961bc9bdd2289a2bda6a3a5a331964ba5497f694e2cbd540d656dc1c"},
+    {file = "coverage-6.2-cp38-cp38-win_amd64.whl", hash = "sha256:9a29311bd6429be317c1f3fe4bc06c4c5ee45e2fa61b2a19d4d1d6111cb94af2"},
+    {file = "coverage-6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:03b20e52b7d31be571c9c06b74746746d4eb82fc260e594dc662ed48145e9efd"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:215f8afcc02a24c2d9a10d3790b21054b58d71f4b3c6f055d4bb1b15cecce685"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a4bdeb0a52d1d04123b41d90a4390b096f3ef38eee35e11f0b22c2d031222c6c"},
+    {file = "coverage-6.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c332d8f8d448ded473b97fefe4a0983265af21917d8b0cdcb8bb06b2afe632c3"},
+    {file = "coverage-6.2-cp39-cp39-win32.whl", hash = "sha256:6e1394d24d5938e561fbeaa0cd3d356207579c28bd1792f25a068743f2d5b282"},
+    {file = "coverage-6.2-cp39-cp39-win_amd64.whl", hash = "sha256:86f2e78b1eff847609b1ca8050c9e1fa3bd44ce755b2ec30e70f2d3ba3844644"},
+    {file = "coverage-6.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:5829192582c0ec8ca4a2532407bc14c2f338d9878a10442f5d03804a95fac9de"},
+    {file = "coverage-6.2.tar.gz", hash = "sha256:e2cad8093172b7d1595b4ad66f24270808658e11acf43a8f95b41276162eb5b8"},
 ]
 flake8 = [
-    {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
-    {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
+    {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},
+    {file = "flake8-3.9.2.tar.gz", hash = "sha256:07528381786f2a6237b061f6e96610a4167b226cb926e2aa2b6b1d78057c576b"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
     {file = "importlib_metadata-1.7.0.tar.gz", hash = "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83"},
 ]
 iniconfig = [
-    {file = "iniconfig-1.0.1-py3-none-any.whl", hash = "sha256:80cf40c597eb564e86346103f609d74efce0f6b4d4f30ec8ce9e2c26411ba437"},
-    {file = "iniconfig-1.0.1.tar.gz", hash = "sha256:e5f92f89355a67de0595932a6c6c02ab4afddc6fcdc0bfc5becd0d60884d3f69"},
+    {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
+    {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 mccabe = [
     {file = "mccabe-0.6.1-py2.py3-none-any.whl", hash = "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42"},
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
-more-itertools = [
-    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
-    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
-]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
+    {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
 ]
 pluggy = [
-    {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
-    {file = "pluggy-0.13.1.tar.gz", hash = "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0"},
+    {file = "pluggy-1.0.0-py2.py3-none-any.whl", hash = "sha256:74134bbf457f031a36d68416e1509f34bd5ccc019f0bcc952c7b909d06b37bd3"},
+    {file = "pluggy-1.0.0.tar.gz", hash = "sha256:4224373bacce55f955a878bf9cfa763c1e360858e330072059e10bad68531159"},
 ]
 py = [
-    {file = "py-1.9.0-py2.py3-none-any.whl", hash = "sha256:366389d1db726cd2fcfc79732e75410e5fe4d31db13692115529d34069a043c2"},
-    {file = "py-1.9.0.tar.gz", hash = "sha256:9ca6883ce56b4e8da7e79ac18787889fa5206c79dcc67fb065376cd2fe03f342"},
+    {file = "py-1.11.0-py2.py3-none-any.whl", hash = "sha256:607c53218732647dff4acdfcd50cb62615cedf612e72d1724fb1a0cc6405b378"},
+    {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
-    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
+    {file = "pycodestyle-2.7.0-py2.py3-none-any.whl", hash = "sha256:514f76d918fcc0b55c6680472f0a37970994e07bbb80725808c17089be302068"},
+    {file = "pycodestyle-2.7.0.tar.gz", hash = "sha256:c389c1d06bf7904078ca03399a4816f974a1d590090fecea0c63ec26ebaf1cef"},
 ]
 pydocstyle = [
     {file = "pydocstyle-5.1.1-py3-none-any.whl", hash = "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"},
     {file = "pydocstyle-5.1.1.tar.gz", hash = "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
-    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
+    {file = "pyflakes-2.3.1-py2.py3-none-any.whl", hash = "sha256:7893783d01b8a89811dd72d7dfd4d84ff098e5eed95cfa8905b22bbffe52efc3"},
+    {file = "pyflakes-2.3.1.tar.gz", hash = "sha256:f5bc8ecabc05bb9d291eb5203d6810b49040f6ff446a756326104746cc00c1db"},
 ]
 pyparsing = [
-    {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
-    {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
+    {file = "pyparsing-3.0.6-py3-none-any.whl", hash = "sha256:04ff808a5b90911829c55c4e26f75fa5ca8a2f5f36aa3a51f68e27033341d3e4"},
+    {file = "pyparsing-3.0.6.tar.gz", hash = "sha256:d9bdec0013ef1eb5a84ab39a3b3868911598afa494f5faa038647101504e2b81"},
 ]
 pytest = [
-    {file = "pytest-6.0.1-py3-none-any.whl", hash = "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"},
-    {file = "pytest-6.0.1.tar.gz", hash = "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4"},
+    {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
+    {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
 ]
 pytest-cov = [
-    {file = "pytest-cov-2.10.1.tar.gz", hash = "sha256:47bd0ce14056fdd79f93e1713f88fad7bdcc583dcd7783da86ef2f085a0bb88e"},
-    {file = "pytest_cov-2.10.1-py2.py3-none-any.whl", hash = "sha256:45ec2d5182f89a81fc3eb29e3d1ed3113b9e9a873bcddb2a71faaab066110191"},
+    {file = "pytest-cov-2.12.1.tar.gz", hash = "sha256:261ceeb8c227b726249b376b8526b600f38667ee314f910353fa318caa01f4d7"},
+    {file = "pytest_cov-2.12.1-py2.py3-none-any.whl", hash = "sha256:261bb9e47e65bd099c89c3edf92972865210c36813f80ede5277dceb77a4a62a"},
 ]
-six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
 ]
 snowballstemmer = [
-    {file = "snowballstemmer-2.0.0-py2.py3-none-any.whl", hash = "sha256:209f257d7533fdb3cb73bdbd24f436239ca3b2fa67d56f6ff88e86be08cc5ef0"},
-    {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
+    {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
+    {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 zipp = [
-    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
-    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
+    {file = "zipp-3.6.0-py3-none-any.whl", hash = "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"},
+    {file = "zipp-3.6.0.tar.gz", hash = "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonschema2md"
-version = "0.2.1"
+version = "0.2.2"
 description = "Convert JSON Schema to human-readable Markdown documentation"
 authors = ["Ralf Gabriels <ralfg@hotmail.be>"]
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "jsonschema2md"
-version = "0.2.2"
+version = "0.3.0"
 description = "Convert JSON Schema to human-readable Markdown documentation"
 authors = ["Ralf Gabriels <ralfg@hotmail.be>"]
 license = "Apache-2.0"
@@ -22,8 +22,9 @@ jsonschema2md = 'jsonschema2md:main'
 
 [tool.poetry.dependencies]
 python = "^3.6"
-click = "^7"
+click = ">=7"
 importlib_metadata = { version = "^1", python = "<3.8"}
+PyYAML = ">=5.1"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.3"

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -33,24 +33,20 @@ class TestParser:
         "examples": [
             {
                 "fruits": ["apple", "orange"],
-                "vegetables": [{"veggieName": "cabbage", "veggieLike": True}]
+                "vegetables": [{"veggieName": "cabbage", "veggieLike": True}],
             }
         ],
     }
 
     def test_construct_description_line(self):
         test_cases = [
-            {
-                "input": {},
-                "add_type": False,
-                "expected_output": ""
-            },
+            {"input": {}, "add_type": False, "expected_output": ""},
             {
                 "input": {
                     "description": "The name of the vegetable.",
                 },
                 "add_type": False,
-                "expected_output": ": The name of the vegetable."
+                "expected_output": ": The name of the vegetable.",
             },
             {
                 "input": {
@@ -58,7 +54,7 @@ class TestParser:
                     "default": "eggplant",
                     "type": "string",
                     "$ref": "#/definitions/veggies",
-                    "enum": ["eggplant", "spinach", "cabbage"]
+                    "enum": ["eggplant", "spinach", "cabbage"],
                 },
                 "add_type": True,
                 "expected_output": (
@@ -66,7 +62,7 @@ class TestParser:
                     "Must be one of: `['eggplant', 'spinach', 'cabbage']`. "
                     "Refer to *#/definitions/veggies*. "
                     "Default: `eggplant`."
-                )
+                ),
             },
             {
                 "input": {
@@ -81,7 +77,7 @@ class TestParser:
                 "expected_output": (
                     ": Number of vegetables. Minimum: `0`. Maximum: `999`. "
                     "Can contain additional properties. Default: `0`."
-                )
+                ),
             },
             {
                 "input": {
@@ -94,31 +90,61 @@ class TestParser:
                 "expected_output": (
                     ": List of vegetables. Cannot contain additional properties. "
                     "Default: `[]`."
-                )
-            }
+                ),
+            },
         ]
 
         parser = jsonschema2md.Parser()
 
         for case in test_cases:
-            observed_output = " ".join(parser._construct_description_line(
-                case["input"], add_type=case["add_type"]
-            ))
+            observed_output = " ".join(
+                parser._construct_description_line(
+                    case["input"], add_type=case["add_type"]
+                )
+            )
             assert case["expected_output"] == observed_output
 
     def test_parse_object(self):
         parser = jsonschema2md.Parser()
-        expected_output = [
-            '- **`fruits`** *(array)*\n',
-            '  - **Items** *(string)*\n'
-        ]
+        expected_output = ["- **`fruits`** *(array)*\n", "  - **Items** *(string)*\n"]
         assert expected_output == parser._parse_object(
-            self.test_schema["properties"]["fruits"],
-            "fruits"
+            self.test_schema["properties"]["fruits"], "fruits"
         )
 
     def test_parse_schema(self):
         parser = jsonschema2md.Parser()
+        expected_output = [
+            "# JSON Schema\n\n",
+            "*Vegetable preferences*\n\n",
+            "## Properties\n\n",
+            "- **`fruits`** *(array)*\n",
+            "  - **Items** *(string)*\n",
+            "- **`vegetables`** *(array)*\n",
+            "  - **Items**: Refer to *#/definitions/veggie*.\n",
+            "## Definitions\n\n",
+            "- **`veggie`** *(object)*\n",
+            "  - **`veggieName`** *(string)*: The name of the vegetable.\n",
+            "  - **`veggieLike`** *(boolean)*: Do I like this vegetable?\n",
+            "## Examples\n\n",
+            "  ```json\n"
+            "  {\n"
+            '      "fruits": [\n'
+            '          "apple",\n'
+            '          "orange"\n'
+            "      ],\n"
+            '      "vegetables": [\n'
+            "          {\n"
+            '              "veggieName": "cabbage",\n'
+            '              "veggieLike": true\n'
+            "          }\n"
+            "      ]\n"
+            "  }\n"
+            "  ```\n\n",
+        ]
+        assert expected_output == parser.parse_schema(self.test_schema)
+
+    def test_parse_schema_examples_yaml(self):
+        parser = jsonschema2md.Parser(examples_as_yaml=True)
         expected_output = [
             '# JSON Schema\n\n',
             '*Vegetable preferences*\n\n',
@@ -132,19 +158,6 @@ class TestParser:
             '  - **`veggieName`** *(string)*: The name of the vegetable.\n',
             '  - **`veggieLike`** *(boolean)*: Do I like this vegetable?\n',
             '## Examples\n\n',
-            '  ```json\n'
-            '  {\n'
-            '      "fruits": [\n'
-            '          "apple",\n'
-            '          "orange"\n'
-            '      ],\n'
-            '      "vegetables": [\n'
-            '          {\n'
-            '              "veggieName": "cabbage",\n'
-            '              "veggieLike": true\n'
-            '          }\n'
-            '      ]\n'
-            '  }\n'
-            '  ```\n\n'
+            '  ```yaml\n  fruits:\n  - apple\n  - orange\n  vegetables:\n  -   veggieLike: true\n      veggieName: cabbage\n  ```\n\n'
         ]
         assert expected_output == parser.parse_schema(self.test_schema)

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -145,7 +145,6 @@ class TestParser:
             '          }\n'
             '      ]\n'
             '  }\n'
-            '  ```\n'
+            '  ```\n\n'
         ]
         assert expected_output == parser.parse_schema(self.test_schema)
-        


### PR DESCRIPTION
### Fixes
- Add `\n\n` at the end of example block
  - Fixes #4
- Relax Click version requirement
  - Fixes #7

### New features
- Option `examples-as-yaml` to show examples in YAML-format instead of JSON
- Option `show-example` to select which examples need to be parsed: `all`, `object`, or `properties`