### PR TITLE
Add support for exclusive{Minimum,Maximum}

### DIFF
--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -80,8 +80,12 @@ class Parser:
                 description_line.append(f"Must be of type *{obj['type']}*.")
         if "minimum" in obj:
             description_line.append(f"Minimum: `{obj['minimum']}`.")
+        if "exclusiveMinimum" in obj:
+            description_line.append(f"Exclusive minimum: `{obj['exclusiveMinimum']}`.")
         if "maximum" in obj:
             description_line.append(f"Maximum: `{obj['maximum']}`.")
+        if "exclusiveMaximum" in obj:
+            description_line.append(f"Exclusive maximum: `{obj['exclusiveMaximum']}`.")
         if "enum" in obj:
             description_line.append(f"Must be one of: `{obj['enum']}`.")
         if "additionalProperties" in obj:

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -91,6 +91,20 @@ class TestParser:
             },
             {
                 "input": {
+                    "description": "Number of vegetables",
+                    "default": 1,
+                    "type": "integer",
+                    "exclusiveMinimum": 0,
+                    "exclusiveMaximum": 1000,
+                },
+                "add_type": False,
+                "expected_output": (
+                    ": Number of vegetables. Exclusive minimum: `0`. "
+                    "Exclusive maximum: `1000`. Default: `1`."
+                ),
+            },
+            {
+                "input": {
                     "description": "List of vegetables",
                     "default": [],
                     "type": "array",


### PR DESCRIPTION
Adds `exclusiveMinimum` and `exclusiveMaximum` bounds to description line if keywords present, mirroring existing formatting for `minimum` and `maximum`. This addition would mean [all of the keywords for specifying range constraints on numeric properties](https://json-schema.org/understanding-json-schema/reference/numeric.html#range) are supported. An additional test case covering the two new keywords is also added.