### PR TITLE
Add support for schema composition keywords

### DIFF
--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -249,3 +249,53 @@ class TestParser:
         ]
 
         assert expected_output == parser.parse_schema(test_schema)
+
+    def test_schema_composition_keywords(self):
+        parser = jsonschema2md.Parser()
+        test_schema = {
+            "$id": "https://example.com/arrays.schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "description": "Schema composition test case",
+            "type": "object",
+            "properties": {
+                "all_of_example": {
+                    "allOf": [
+                        { "type": "number" },
+                        { "type": "integer" },
+                    ]
+                },
+                "any_of_example": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "number", "minimum": 0 }
+                    ]
+                },
+                "one_of_example": {
+                    "default": [1, 2, 3],
+                    "oneOf": [
+                        { "type": "null" },
+                        { "type": "array", "items": {"type": "number"}},
+                    ]
+                },
+
+            }
+        }
+        expected_output = [
+            "# JSON Schema\n\n",
+            "*Schema composition test case*\n\n",
+            "## Properties\n\n",
+            "- **`all_of_example`**\n",
+            "  - **All of**\n",
+            "    - *number*\n",
+            "    - *integer*\n",
+            "- **`any_of_example`**\n",
+            "  - **Any of**\n",
+            "    - *string*\n",
+            "    - *number*: Minimum: `0`.\n",
+            "- **`one_of_example`**: Default: `[1, 2, 3]`.\n",
+            "  - **One of**\n",
+            "    - *null*\n",
+            "    - *array*\n",
+            "      - **Items** *(number)*\n"
+        ]
+        assert expected_output == parser.parse_schema(test_schema)


### PR DESCRIPTION
Fixes #2 

Adds support for parsing [schema composition keywords `oneOf`, `anyOf` and `allOf`](http://json-schema.org/understanding-json-schema/reference/combining.html), which allow combining schemas together. In all three cases the values associated with the keywords are arrays of subschemas; these are represented in Markdown as a list with each item a subschema, nested with an outer list item corresponding to the composition keyword. As the subschemas do not have keys with which to use for the name field in the Markdown representation, the `_parse_object` method has also been updated to make `name` an optional argument with adjusted formatting if no name is specified. A test is also added for a schema covering the three different keywords.