### PR TITLE
Add support for {min,max}Items keywords

### DIFF
--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -82,6 +82,19 @@ class Parser:
             description_line.append(f"Minimum: `{obj['minimum']}`.")
         if "maximum" in obj:
             description_line.append(f"Maximum: `{obj['maximum']}`.")
+        if "minItems" in obj or "maxItems" in obj:
+            length_description = "Length must be "
+            if "minItems" in obj and "maxItems" not in obj:
+                length_description += f"at least {obj['minItems']}."
+            elif "maxItems" in obj and "minItems" not in obj:
+                length_description += f"at most {obj['maxItems']}."
+            elif obj["minItems"] == obj["maxItems"]:
+                length_description += f"equal to {obj['minItems']}."
+            else:
+                length_description += (
+                    f"between {obj['minItems']} and {obj['maxItems']} (inclusive)."
+                )
+            description_line.append(length_description)
         if "enum" in obj:
             description_line.append(f"Must be one of: `{obj['enum']}`.")
         if "additionalProperties" in obj:

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -102,6 +102,64 @@ class TestParser:
                     "Default: `[]`."
                 ),
             },
+            {
+                "input": {
+                    "description": "List of vegetables",
+                    "default": ["Carrot"],
+                    "type": "array",
+                    "minItems": 1,
+                },
+                "add_type": False,
+                "expected_output": (
+                    ": List of vegetables. "
+                    "Length must be at least 1. "
+                    "Default: `['Carrot']`."
+                ),
+            },
+            {
+                "input": {
+                    "description": "List of vegetables",
+                    "default": ["Carrot"],
+                    "type": "array",
+                    "maxItems": 10,
+                },
+                "add_type": False,
+                "expected_output": (
+                    ": List of vegetables. "
+                    "Length must be at most 10. "
+                    "Default: `['Carrot']`."
+                ),
+            },
+            {
+                "input": {
+                    "description": "List of vegetables",
+                    "default": ["Carrot"],
+                    "type": "array",
+                    "minItems": 1,
+                    "maxItems": 10,
+                },
+                "add_type": False,
+                "expected_output": (
+                    ": List of vegetables. "
+                    "Length must be between 1 and 10 (inclusive). "
+                    "Default: `['Carrot']`."
+                ),
+            },
+            {
+                "input": {
+                    "description": "List of vegetables",
+                    "default": ["Carrot", "Mushroom", "Cabbage", "Broccoli", "Leek"],
+                    "type": "array",
+                    "minItems": 5,
+                    "maxItems": 5,
+                },
+                "add_type": False,
+                "expected_output": (
+                    ": List of vegetables. "
+                    "Length must be equal to 5. "
+                    "Default: `['Carrot', 'Mushroom', 'Cabbage', 'Broccoli', 'Leek']`."
+                ),
+            },
         ]
 
         parser = jsonschema2md.Parser()


### PR DESCRIPTION
Adds support for `minItems` and `maxItems` keywords for validating length of properties of `array` type. Adds a textual description of constraints on array length to description line based on presence and values of `minItems` and `maxItems` keywords. Test cases are also added to cover the four different combinations (only `minItems` specified, only `maxItems` specified, `minItems` and `maxItems` both specified but not equal, `minItems` and `maxItems` both specified and equal to each other).