### PR TITLE
Use JSON representations for default and enum values

### DIFF
--- a/jsonschema2md.py
+++ b/jsonschema2md.py
@@ -83,7 +83,7 @@ class Parser:
         if "maximum" in obj:
             description_line.append(f"Maximum: `{obj['maximum']}`.")
         if "enum" in obj:
-            description_line.append(f"Must be one of: `{obj['enum']}`.")
+            description_line.append(f"Must be one of: `{json.dumps(obj['enum'])}`.")
         if "additionalProperties" in obj:
             if obj["additionalProperties"]:
                 description_line.append("Can contain additional properties.")
@@ -92,7 +92,7 @@ class Parser:
         if "$ref" in obj:
             description_line.append(f"Refer to *{obj['$ref']}*.")
         if "default" in obj:
-            description_line.append(f"Default: `{obj['default']}`.")
+            description_line.append(f"Default: `{json.dumps(obj['default'])}`.")
 
         # Only add start colon if items were added
         if description_line:

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -69,9 +69,9 @@ class TestParser:
                 "add_type": True,
                 "expected_output": (
                     ": The name of the vegetable. Must be of type *string*. "
-                    "Must be one of: `['eggplant', 'spinach', 'cabbage']`. "
+                    "Must be one of: `[\"eggplant\", \"spinach\", \"cabbage\"]`. "
                     "Refer to *#/definitions/veggies*. "
-                    "Default: `eggplant`."
+                    "Default: `\"eggplant\"`."
                 ),
             },
             {


### PR DESCRIPTION
Fixes #14 

Uses `json.dumps` to convert values associated with `default` and `enum` keywords to corresponding JSON string representations rather than using Python representations of values as currently. Updates expected output in affected test case correspondingly.