### PR TITLE
add token replacement in output file

### DIFF
--- a/tests/templates/rendered_template.md
+++ b/tests/templates/rendered_template.md
@@ -1,0 +1,26 @@
+# Title of docs
+
+## subsection for json schema for fruits
+<!--- fruits:START -->
+# Fruits
+
+*Fruits I like*
+
+## Items
+
+- **Items** *(object)*: A list of fruits.
+  - **`name`** *(string)*: The name of the fruit.
+  - **`sweet`** *(boolean)*: Whether it is sweet or not.
+<!--- fruits:END -->
+
+## subsection for json schema for veggies
+<!--- veggies:START -->
+# Veggies
+
+*Veggies I like*
+
+## Items
+
+- **Items** *(object)*: A list of veggies.
+  - **`name`** *(string)*: The name of the veggie.
+<!--- veggies:END -->

--- a/tests/templates/template.md
+++ b/tests/templates/template.md
@@ -1,0 +1,9 @@
+# Title of docs
+
+## subsection for json schema for fruits
+<!--- fruits:START -->
+<!--- fruits:END -->
+
+## subsection for json schema for veggies
+<!--- veggies:START -->
+<!--- veggies:END -->

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -1,7 +1,13 @@
 """Test jsonschema2md."""
 
+import os
+import shutil
+import tempfile
 
 import jsonschema2md
+from jsonschema2md import write_lines_between_token
+
+TEST_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestParser:
@@ -249,3 +255,59 @@ class TestParser:
         ]
 
         assert expected_output == parser.parse_schema(test_schema)
+
+    def test_token_replacement(self):
+        parser = jsonschema2md.Parser()
+
+        fruit_schema = {
+            "$id": "https://example.com/arrays.schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Fruits",
+            "description": "Fruits I like",
+            "type": "array",
+            "items": {
+                "description": "A list of fruits",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The name of the fruit",
+                        "type": "string"
+                    },
+                    "sweet": {
+                        "description": "Whether it is sweet or not",
+                        "type": "boolean",
+                    }
+                }
+            },
+        }
+        veg_schema = {
+            "$id": "https://example.com/arrays.schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Veggies",
+            "description": "Veggies I like",
+            "type": "array",
+            "items": {
+                "description": "A list of veggies",
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "description": "The name of the veggie",
+                        "type": "string"
+                    }
+                }
+            },
+        }
+        
+        out_file = tempfile.NamedTemporaryFile()
+        shutil.copy2(f"{TEST_DIR}/templates/template.md", out_file.name)
+
+        with open(f"{TEST_DIR}/templates/rendered_template.md") as f:
+            expected_output = f.read()
+
+        write_lines_between_token(out_file.name, parser.parse_schema(fruit_schema), "fruits")
+        write_lines_between_token(out_file.name, parser.parse_schema(veg_schema), "veggies")
+
+        with open(out_file.name) as f:
+            assert expected_output == f.read()
+
+

--- a/tests/test_jsonschema2md.py
+++ b/tests/test_jsonschema2md.py
@@ -249,3 +249,53 @@ class TestParser:
         ]
 
         assert expected_output == parser.parse_schema(test_schema)
+
+    def test_schema_composition_keywords(self):
+        parser = jsonschema2md.Parser()
+        test_schema = {
+            "$id": "https://example.com/arrays.schema.json",
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "description": "Schema composition test case",
+            "type": "object",
+            "properties": {
+                "all_of_example": {
+                    "allOf": [
+                        { "type": "number" },
+                        { "type": "integer" },
+                    ]
+                },
+                "any_of_example": {
+                    "anyOf": [
+                        { "type": "string" },
+                        { "type": "number", "minimum": 0 }
+                    ]
+                },
+                "one_of_example": {
+                    "default": [1, 2, 3],
+                    "oneOf": [
+                        { "type": "null" },
+                        { "type": "array", "items": {"type": "number"}},
+                    ]
+                },
+
+            }
+        }
+        expected_output = [
+            "# JSON Schema\n\n",
+            "*Schema composition test case*\n\n",
+            "## Properties\n\n",
+            "- **`all_of_example`**\n",
+            "  - **All of**\n",
+            "    - *number*\n",
+            "    - *integer*\n",
+            "- **`any_of_example`**\n",
+            "  - **Any of**\n",
+            "    - *string*\n",
+            "    - *number*: Minimum: `0`.\n",
+            "- **`one_of_example`**: Default: `[1, 2, 3]`.\n",
+            "  - **One of**\n",
+            "    - *null*\n",
+            "    - *array*\n",
+            "      - **Items** *(number)*\n"
+        ]
+        assert expected_output == parser.parse_schema(test_schema)


### PR DESCRIPTION
this adds a feature where instead of overwriting an entire output file you can search for tokens comments in the output markdown file to replace a particular section.  this is useful in scenarios where several schemas need to be populated in the same file or there is other boilerplate content needed in the output file.

for example

```md
# Top level title
project description

## subsection for fruits
<!-- fruits:START -->
<!-- fruits:END -->

## subsection for veggies
<!-- veggies:START -->
<!-- veggies:END -->
```